### PR TITLE
adding action to generate webpages

### DIFF
--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -29,7 +29,7 @@ jobs:
         run: |
           cd website
           python create_indicator_webpages.py
-        shell: bash
+        shell: micromamba-shell {0}
 
       - name: Deploy 🚀
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -27,6 +27,7 @@ jobs:
 
       - name: create HTML file
         run: |
+          micromamba activate H3_indicators
           cd website
           python create_indicator_webpages.py
 

--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -10,7 +10,7 @@ on:
     branches:
       - main
     paths:
-      - 'data/*.geojson'
+      - 'data/**'
 
 jobs:
   build:

--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -1,0 +1,38 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Create and Deploy Prod HTML site
+# Includes building automatically when either of the relevant JSON files update on the main branch or on the push of a button
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/*.geojson'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          init-shell: bash
+          environment-file: environment.yml
+
+      - name: create HTML file
+        run: |
+          cd website
+          python create_indicator_webpages.py
+
+      - name: Deploy 🚀
+        if: github.ref == 'refs/heads/main'
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: website/deploy # The folder the action should deploy.
+          repository-name: MathewBiddle/H3_indicators

--- a/.github/workflows/website_create_and_deploy.yml
+++ b/.github/workflows/website_create_and_deploy.yml
@@ -27,9 +27,9 @@ jobs:
 
       - name: create HTML file
         run: |
-          micromamba activate H3_indicators
           cd website
           python create_indicator_webpages.py
+        shell: bash
 
       - name: Deploy 🚀
         if: github.ref == 'refs/heads/main'

--- a/README.md
+++ b/README.md
@@ -17,5 +17,7 @@ The data sourced for this effort comes from the publicly available OBIS snapshot
 
 Manually, the `.html` interactive maps are then served via GitHub Pages in the `gh-pages` branch. To view the interactive maps, browse to https://noaa-gis4ocean.github.io/H3_indicators/.
 
+Testing GH-Actions currently.
+
 ## 🖐️ Want to help out?
 * Check out our [CONTRIBUTING GUIDE](https://github.com/NOAA-GIS4Ocean/H3_indicators/blob/main/CONTRIBUTING.md) for more details.

--- a/data/README.md
+++ b/data/README.md
@@ -4,6 +4,8 @@ This directory contains biodiversity indicator files on an [H3 grid](https://h3g
 
 The indicators were developed using the R [obisindicators](https://github.com/marinebon/obisindicators) package.
 
+Indicators include: ES50,
+
 The source data are from the OBIS snapshot `obis_20240723.parquet`.
 
 The filename convention is as follows: indicators_all_res[resolution].geojson

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: H3_indicators
+channels:
+  - conda-forge
+dependencies:
+  - python=3.12
+  - geopandas>=0.13.2
+  - numpy
+  - pandas

--- a/website/create_indicator_webpages.py
+++ b/website/create_indicator_webpages.py
@@ -1,0 +1,18 @@
+import geopandas as gpd
+import numpy as np
+import os
+
+for i in range(1,7):
+  url = "https://raw.githubusercontent.com/NOAA-GIS4Ocean/H3_indicators/main/data/indicators_all_res{}.geojson".format(i)
+
+  gdf = gpd.read_file(url)
+  gdf["log10(n)"] = np.log10(gdf["n"])
+
+  m = gdf.explore(
+     column = "log10(n)"
+     )
+
+  filename = url.split("/")[-1].replace(".geojson",".html")
+  fout = os.path.join("deploy", filename)
+
+  m.save(fout)

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -3,20 +3,12 @@
 <h1>Index of /H3_indicators/</h1>
 <hr>
 <pre>
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res1.html">indicators_all_res1.html</a>
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res2.html">indicators_all_res2.html</a>
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res3.html">indicators_all_res3.html</a>
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res4.html">indicators_all_res4.html</a>
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res4.html">indicators_all_res4.html</a>
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res5.html">indicators_all_res5.html</a> 	This one takes a while to load.
-<a
-href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res6.html">indicators_all_res6.html</a>	This one takes even longer.
+<a href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res1.html">indicators_all_res1.html</a>
+<a href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res2.html">indicators_all_res2.html</a>
+<a href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res3.html">indicators_all_res3.html</a>
+<a href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res4.html">indicators_all_res4.html</a>
+<a href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res5.html">indicators_all_res5.html</a> 	This one takes a while to load.
+<a href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res6.html">indicators_all_res6.html</a>	This one takes even longer.
 </pre>
 <hr>
 

--- a/website/deploy/index.html
+++ b/website/deploy/index.html
@@ -1,0 +1,23 @@
+<head><title>Index of /H3_indicators/</title></head>
+<body bgcolor="white">
+<h1>Index of /H3_indicators/</h1>
+<hr>
+<pre>
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res1.html">indicators_all_res1.html</a>
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res2.html">indicators_all_res2.html</a>
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res3.html">indicators_all_res3.html</a>
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res4.html">indicators_all_res4.html</a>
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res4.html">indicators_all_res4.html</a>
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res5.html">indicators_all_res5.html</a> 	This one takes a while to load.
+<a
+href="https://noaa-gis4ocean.github.io/H3_indicators/indicators_all_res6.html">indicators_all_res6.html</a>	This one takes even longer.
+</pre>
+<hr>
+
+</body>


### PR DESCRIPTION
This adds a GitHub Action to generate the html webpages from the source data/*.geojson files. 

It will only run when files in the `data/` directory are changed or when manually triggered.

Once merged, the workflow needs to have `repository-name` updated to reflect the change in organization.

The settings in the repo need to change to have pages publish from gh-actions